### PR TITLE
feat: configurable text chunking with multiple modes

### DIFF
--- a/src/adapters/outbound.ts
+++ b/src/adapters/outbound.ts
@@ -1,5 +1,5 @@
 import type { ResolvedKakaoTalkChannel } from "../types.js";
-import { chunkTextForKakao as chunkTextForKakaoImpl } from "../kakao/response.js";
+import { chunkTextForKakao as chunkTextForKakaoImpl, type ChunkMode } from "../kakao/response.js";
 
 export interface OutboundContext {
   to: string;
@@ -19,18 +19,20 @@ export interface ChannelOutboundAdapter {
   deliveryMode: "direct" | "gateway";
   textChunkLimit: number;
   chunkerMode: "text" | "markdown";
-  chunker: (text: string, limit: number) => string[];
+  chunkMode: ChunkMode;
+  chunker: (text: string, limit: number, mode?: ChunkMode) => string[];
   sendText: (ctx: OutboundContext) => Promise<OutboundResult>;
 }
 
-export function chunkTextForKakao(text: string, limit: number = 500): string[] {
-  return chunkTextForKakaoImpl(text, limit);
+export function chunkTextForKakao(text: string, limit: number = 400, mode: ChunkMode = "sentence"): string[] {
+  return chunkTextForKakaoImpl(text, limit, mode);
 }
 
 export const outboundAdapter: ChannelOutboundAdapter = {
   deliveryMode: "direct",
-  textChunkLimit: 500,
+  textChunkLimit: 400,
   chunkerMode: "text",
+  chunkMode: "sentence",
   chunker: chunkTextForKakao,
 
   sendText: async (_ctx: OutboundContext): Promise<OutboundResult> => {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -47,6 +47,18 @@ export const KakaoAccountConfigSchema = z.object({
 
   /** @internal SSE 재연결 최대 지연 시간 (ms) */
   maxReconnectDelayMs: z.number().min(5000).max(60000).default(30000),
+
+  // ─────────────────────────────────────────────────────────────
+  // 텍스트 처리 설정
+  // ─────────────────────────────────────────────────────────────
+  /** 텍스트 청크 최대 길이 (카카오 simpleText: 400자 표시, 1000자 전체) */
+  textChunkLimit: z.number()
+    .min(100, "textChunkLimit은 최소 100자 이상이어야 합니다")
+    .max(1000, "textChunkLimit은 최대 1000자 이하여야 합니다")
+    .default(400),
+
+  /** 텍스트 청킹 모드: sentence(문장 경계), newline(빈 줄), length(정확한 길이) */
+  chunkMode: z.enum(["sentence", "newline", "length"]).default("sentence"),
 });
 
 /**

--- a/src/kakao/response.ts
+++ b/src/kakao/response.ts
@@ -140,21 +140,11 @@ export function buildErrorResponse(message: string): KakaoSkillResponse {
   };
 }
 
-/**
- * Chunk text for Kakao's 500-char visible limit
- *
- * Splits text at sentence boundaries (. ! ?) to maintain readability.
- * Falls back to hard limit if no sentence boundary found.
- *
- * @param text - Text to chunk
- * @param limit - Character limit per chunk (default: 500)
- * @returns Array of text chunks
- */
-export function chunkTextForKakao(text: string, limit: number = 500): string[] {
-  if (!text || text.length <= limit) {
-    return [text];
-  }
+export type ChunkMode = "sentence" | "newline" | "length";
 
+const DEFAULT_CHUNK_LIMIT = 400;
+
+function chunkBySentence(text: string, limit: number): string[] {
   const chunks: string[] = [];
   let remaining = text;
 
@@ -164,7 +154,6 @@ export function chunkTextForKakao(text: string, limit: number = 500): string[] {
       break;
     }
 
-    // Try to find sentence boundary within limit
     const substring = remaining.substring(0, limit);
     const lastSentenceEnd = Math.max(
       substring.lastIndexOf("."),
@@ -173,17 +162,86 @@ export function chunkTextForKakao(text: string, limit: number = 500): string[] {
     );
 
     if (lastSentenceEnd > 0) {
-      // Found sentence boundary, include the punctuation
       chunks.push(remaining.substring(0, lastSentenceEnd + 1));
       remaining = remaining.substring(lastSentenceEnd + 1).trim();
     } else {
-      // No sentence boundary, hard split at limit
       chunks.push(remaining.substring(0, limit));
       remaining = remaining.substring(limit).trim();
     }
   }
 
   return chunks;
+}
+
+function chunkByNewline(text: string, limit: number): string[] {
+  const paragraphs = text.split(/\n\s*\n/);
+  const chunks: string[] = [];
+  let currentChunk = "";
+
+  for (const paragraph of paragraphs) {
+    const trimmed = paragraph.trim();
+    if (!trimmed) continue;
+
+    if (currentChunk.length === 0) {
+      if (trimmed.length <= limit) {
+        currentChunk = trimmed;
+      } else {
+        chunks.push(...chunkBySentence(trimmed, limit));
+      }
+    } else if (currentChunk.length + 2 + trimmed.length <= limit) {
+      currentChunk += "\n\n" + trimmed;
+    } else {
+      chunks.push(currentChunk);
+      if (trimmed.length <= limit) {
+        currentChunk = trimmed;
+      } else {
+        chunks.push(...chunkBySentence(trimmed, limit));
+        currentChunk = "";
+      }
+    }
+  }
+
+  if (currentChunk) {
+    chunks.push(currentChunk);
+  }
+
+  return chunks;
+}
+
+function chunkByLength(text: string, limit: number): string[] {
+  const chunks: string[] = [];
+  let remaining = text;
+
+  while (remaining.length > 0) {
+    if (remaining.length <= limit) {
+      chunks.push(remaining);
+      break;
+    }
+    chunks.push(remaining.substring(0, limit));
+    remaining = remaining.substring(limit);
+  }
+
+  return chunks;
+}
+
+export function chunkTextForKakao(
+  text: string,
+  limit: number = DEFAULT_CHUNK_LIMIT,
+  mode: ChunkMode = "sentence"
+): string[] {
+  if (!text || text.length <= limit) {
+    return [text];
+  }
+
+  switch (mode) {
+    case "newline":
+      return chunkByNewline(text, limit);
+    case "length":
+      return chunkByLength(text, limit);
+    case "sentence":
+    default:
+      return chunkBySentence(text, limit);
+  }
 }
 
 export function buildMultiTextResponse(texts: string[]): KakaoSkillResponse {

--- a/src/types.ts
+++ b/src/types.ts
@@ -299,6 +299,10 @@ export interface KakaoChannelConfig {
   reconnectDelayMs?: number;
   /** @internal */
   maxReconnectDelayMs?: number;
+
+  // 텍스트 처리 설정
+  textChunkLimit?: number;
+  chunkMode?: "sentence" | "newline" | "length";
 }
 
 export interface ResolvedKakaoTalkChannel {

--- a/tests/integration/plugin-export.test.ts
+++ b/tests/integration/plugin-export.test.ts
@@ -58,7 +58,7 @@ describe('Plugin Export', () => {
     it('should have outbound adapter', () => {
       expect(kakaoPlugin.outbound).toBeDefined();
       expect(kakaoPlugin.outbound.sendText).toBeTypeOf('function');
-      expect(kakaoPlugin.outbound.textChunkLimit).toBe(500);
+      expect(kakaoPlugin.outbound.textChunkLimit).toBe(400);
     });
     
     it('should have optional adapters', () => {

--- a/tests/unit/adapters/outbound.test.ts
+++ b/tests/unit/adapters/outbound.test.ts
@@ -27,7 +27,6 @@ const mockTalkChannel: ResolvedKakaoTalkChannel = {
   config: {
     enabled: true,
     channelId: "channel_123",
-    mode: "direct",
     dmPolicy: "open",
   },
 };
@@ -49,12 +48,16 @@ describe("ChannelOutboundAdapter - Configuration", () => {
     expect(outboundAdapter.deliveryMode).toBe("direct");
   });
 
-  it("should have textChunkLimit set to 500", () => {
-    expect(outboundAdapter.textChunkLimit).toBe(500);
+  it("should have textChunkLimit set to 400", () => {
+    expect(outboundAdapter.textChunkLimit).toBe(400);
   });
 
   it("should have chunkerMode set to 'text'", () => {
     expect(outboundAdapter.chunkerMode).toBe("text");
+  });
+
+  it("should have chunkMode set to 'sentence'", () => {
+    expect(outboundAdapter.chunkMode).toBe("sentence");
   });
 
   it("should have chunker function defined", () => {
@@ -145,13 +148,13 @@ describe("chunkTextForKakao", () => {
     expect(rejoined.replace(/\s+/g, " ")).toContain("Fifth");
   });
 
-  it("should use default limit of 500 when not specified", () => {
+  it("should use default limit of 400 when not specified", () => {
     const text = "a".repeat(600);
     const chunks = chunkTextForKakao(text);
 
     expect(chunks.length).toBeGreaterThan(1);
     chunks.forEach((chunk) => {
-      expect(chunk.length).toBeLessThanOrEqual(500);
+      expect(chunk.length).toBeLessThanOrEqual(400);
     });
   });
 });

--- a/tests/unit/config/schema.test.ts
+++ b/tests/unit/config/schema.test.ts
@@ -146,6 +146,75 @@ describe("Config Schema (Simplified)", () => {
         expect(result.data.allowFrom).toEqual(["user1", "user2"]);
       }
     });
+
+    it("should apply default textChunkLimit of 400", () => {
+      const config = {};
+
+      const result = KakaoAccountConfigSchema.safeParse(config);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.textChunkLimit).toBe(400);
+      }
+    });
+
+    it("should accept custom textChunkLimit within range", () => {
+      const config = {
+        textChunkLimit: 1000,
+      };
+
+      const result = KakaoAccountConfigSchema.safeParse(config);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.textChunkLimit).toBe(1000);
+      }
+    });
+
+    it("should reject textChunkLimit below minimum", () => {
+      const config = {
+        textChunkLimit: 50,
+      };
+
+      const result = KakaoAccountConfigSchema.safeParse(config);
+      expect(result.success).toBe(false);
+    });
+
+    it("should reject textChunkLimit above maximum", () => {
+      const config = {
+        textChunkLimit: 2000,
+      };
+
+      const result = KakaoAccountConfigSchema.safeParse(config);
+      expect(result.success).toBe(false);
+    });
+
+    it("should apply default chunkMode of sentence", () => {
+      const config = {};
+
+      const result = KakaoAccountConfigSchema.safeParse(config);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.chunkMode).toBe("sentence");
+      }
+    });
+
+    it("should accept valid chunkMode values", () => {
+      for (const mode of ["sentence", "newline", "length"]) {
+        const result = KakaoAccountConfigSchema.safeParse({ chunkMode: mode });
+        expect(result.success).toBe(true);
+        if (result.success) {
+          expect(result.data.chunkMode).toBe(mode);
+        }
+      }
+    });
+
+    it("should reject invalid chunkMode", () => {
+      const config = {
+        chunkMode: "invalid",
+      };
+
+      const result = KakaoAccountConfigSchema.safeParse(config);
+      expect(result.success).toBe(false);
+    });
   });
 
   describe("KakaoChannelConfigSchema (wrapper)", () => {

--- a/tests/unit/kakao/response.test.ts
+++ b/tests/unit/kakao/response.test.ts
@@ -124,13 +124,13 @@ describe("Kakao Response Builder", () => {
       expect(chunks[0]).toBe(text);
     });
 
-    it("should use default limit of 500 characters", () => {
+    it("should use default limit of 400 characters (sentence mode)", () => {
       const text = "a".repeat(600);
       const chunks = chunkTextForKakao(text);
 
       expect(chunks.length).toBeGreaterThan(1);
       chunks.forEach((chunk) => {
-        expect(chunk.length).toBeLessThanOrEqual(500);
+        expect(chunk.length).toBeLessThanOrEqual(400);
       });
     });
 
@@ -178,7 +178,7 @@ describe("Kakao Response Builder", () => {
 
       expect(chunks.length).toBeGreaterThan(1);
       chunks.forEach((chunk) => {
-        expect(chunk.length).toBeLessThanOrEqual(500);
+        expect(chunk.length).toBeLessThanOrEqual(400);
       });
     });
 
@@ -204,6 +204,105 @@ describe("Kakao Response Builder", () => {
       chunks.forEach((chunk) => {
         expect(chunk.length).toBeLessThanOrEqual(100);
       });
+    });
+
+    it("should use default limit of 400 characters", () => {
+      const text = "a".repeat(500);
+      const chunks = chunkTextForKakao(text);
+
+      expect(chunks.length).toBeGreaterThan(1);
+      chunks.forEach((chunk) => {
+        expect(chunk.length).toBeLessThanOrEqual(400);
+      });
+    });
+  });
+
+  describe("chunkTextForKakao - newline mode", () => {
+    it("should split at paragraph boundaries when exceeds limit", () => {
+      const text = "First paragraph is quite long.\n\nSecond paragraph is also long.\n\nThird paragraph here.";
+      const chunks = chunkTextForKakao(text, 40, "newline");
+
+      expect(chunks.length).toBeGreaterThan(1);
+      chunks.forEach((chunk) => {
+        expect(chunk.length).toBeLessThanOrEqual(40);
+      });
+    });
+
+    it("should combine short paragraphs within limit", () => {
+      const text = "Short.\n\nAlso short.";
+      const chunks = chunkTextForKakao(text, 100, "newline");
+
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0]).toBe("Short.\n\nAlso short.");
+    });
+
+    it("should fall back to sentence chunking for long paragraphs", () => {
+      const text = "This is a very long sentence that exceeds the limit. Another sentence here.\n\nShort.";
+      const chunks = chunkTextForKakao(text, 60, "newline");
+
+      expect(chunks.length).toBeGreaterThanOrEqual(2);
+      chunks.forEach((chunk) => {
+        expect(chunk.length).toBeLessThanOrEqual(60);
+      });
+    });
+
+    it("should skip empty paragraphs when building chunks", () => {
+      const text = "First paragraph here.\n\nSecond paragraph.\n\nThird one.";
+      const chunks = chunkTextForKakao(text, 30, "newline");
+
+      expect(chunks.length).toBeGreaterThan(1);
+      chunks.forEach((chunk) => {
+        expect(chunk.trim()).not.toBe("");
+      });
+    });
+
+    it("should handle Korean paragraphs", () => {
+      const text = "첫 번째 문단입니다.\n\n두 번째 문단입니다.";
+      const chunks = chunkTextForKakao(text, 100, "newline");
+
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0]).toContain("첫 번째");
+      expect(chunks[0]).toContain("두 번째");
+    });
+  });
+
+  describe("chunkTextForKakao - length mode", () => {
+    it("should split at exact character limit", () => {
+      const text = "abcdefghij";
+      const chunks = chunkTextForKakao(text, 3, "length");
+
+      expect(chunks).toHaveLength(4);
+      expect(chunks[0]).toBe("abc");
+      expect(chunks[1]).toBe("def");
+      expect(chunks[2]).toBe("ghi");
+      expect(chunks[3]).toBe("j");
+    });
+
+    it("should not trim whitespace between chunks", () => {
+      const text = "abc def ghi";
+      const chunks = chunkTextForKakao(text, 4, "length");
+
+      expect(chunks[0]).toBe("abc ");
+      expect(chunks[1]).toBe("def ");
+      expect(chunks[2]).toBe("ghi");
+    });
+
+    it("should handle text shorter than limit", () => {
+      const text = "short";
+      const chunks = chunkTextForKakao(text, 100, "length");
+
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0]).toBe("short");
+    });
+
+    it("should handle Korean text", () => {
+      const text = "가나다라마바사";
+      const chunks = chunkTextForKakao(text, 3, "length");
+
+      expect(chunks).toHaveLength(3);
+      expect(chunks[0]).toBe("가나다");
+      expect(chunks[1]).toBe("라마바");
+      expect(chunks[2]).toBe("사");
     });
   });
 


### PR DESCRIPTION
## Summary

- Add configurable text chunking options following OpenClaw channel plugin patterns (Discord, Slack, WhatsApp)
- Change default chunk limit from 500 to 400 characters (Kakao simpleText visible limit)
- Add three chunking modes: `sentence`, `newline`, `length`

## Changes

### Configuration Options

```typescript
// src/config/schema.ts
textChunkLimit: z.number().min(100).max(1000).default(400)
chunkMode: z.enum(["sentence", "newline", "length"]).default("sentence")
```

### Chunking Modes

| Mode | Description | Use Case |
|------|-------------|----------|
| `sentence` | Split at sentence boundaries (. ! ?) | Default, natural text |
| `newline` | Split at paragraph boundaries (blank lines) | Structured content |
| `length` | Hard split at exact character limit | Technical text |

### Files Changed

- `src/config/schema.ts` - Added config options
- `src/types.ts` - Updated `KakaoChannelConfig` type
- `src/kakao/response.ts` - Implemented chunking modes
- `src/adapters/outbound.ts` - Updated adapter with new defaults
- Tests updated with comprehensive coverage

## Testing

All 396 tests pass:
- New tests for `newline` and `length` modes
- Updated existing tests for new default (400 chars)
- Schema validation tests for config options

## Related Issues

Closes #11 (Configurable text chunking 구현)
Also addresses #5 (simpleText 문자 제한 수정)