### PR TITLE
fix: capabilities.media, osLink button, validation constants

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -38,7 +38,7 @@ export const kakaoPlugin = {
     chatTypes: ["direct"] as const,
     reactions: false,
     threads: false,
-    media: false,
+    media: true,
     nativeCommands: false,
     blockStreaming: true,
   },

--- a/src/kakao/limits.ts
+++ b/src/kakao/limits.ts
@@ -1,0 +1,129 @@
+import type { KakaoButton, KakaoQuickReply } from "../types.js";
+
+export const KAKAO_LIMITS = {
+  SIMPLE_TEXT_MAX: 1000,
+  SIMPLE_TEXT_VISIBLE: 400,
+
+  CARD_TITLE: 50,
+  CARD_DESCRIPTION: 230,
+
+  BUTTON_LABEL: 14,
+  QUICK_REPLY_LABEL: 14,
+  QUICK_REPLIES_MAX: 10,
+
+  OUTPUTS_MAX: 3,
+  CAROUSEL_MIN: 2,
+  CAROUSEL_MAX: 10,
+  LIST_ITEMS_MIN: 2,
+  LIST_ITEMS_MAX: 5,
+} as const;
+
+export type ValidationResult = { valid: true } | { valid: false; error: string };
+
+export function validateSimpleText(text: string): ValidationResult {
+  if (text.length > KAKAO_LIMITS.SIMPLE_TEXT_MAX) {
+    return {
+      valid: false,
+      error: `Text exceeds ${KAKAO_LIMITS.SIMPLE_TEXT_MAX} characters (got ${text.length})`,
+    };
+  }
+  return { valid: true };
+}
+
+export function validateCardTitle(title: string): ValidationResult {
+  if (title.length > KAKAO_LIMITS.CARD_TITLE) {
+    return {
+      valid: false,
+      error: `Card title exceeds ${KAKAO_LIMITS.CARD_TITLE} characters (got ${title.length})`,
+    };
+  }
+  return { valid: true };
+}
+
+export function validateCardDescription(description: string): ValidationResult {
+  if (description.length > KAKAO_LIMITS.CARD_DESCRIPTION) {
+    return {
+      valid: false,
+      error: `Card description exceeds ${KAKAO_LIMITS.CARD_DESCRIPTION} characters (got ${description.length})`,
+    };
+  }
+  return { valid: true };
+}
+
+export function validateButton(button: KakaoButton): ValidationResult {
+  if (button.label.length > KAKAO_LIMITS.BUTTON_LABEL) {
+    return {
+      valid: false,
+      error: `Button label exceeds ${KAKAO_LIMITS.BUTTON_LABEL} characters (got ${button.label.length})`,
+    };
+  }
+  return { valid: true };
+}
+
+export function validateQuickReply(reply: KakaoQuickReply): ValidationResult {
+  if (reply.label.length > KAKAO_LIMITS.QUICK_REPLY_LABEL) {
+    return {
+      valid: false,
+      error: `Quick reply label exceeds ${KAKAO_LIMITS.QUICK_REPLY_LABEL} characters (got ${reply.label.length})`,
+    };
+  }
+  return { valid: true };
+}
+
+export function validateQuickReplies(replies: KakaoQuickReply[]): ValidationResult {
+  if (replies.length > KAKAO_LIMITS.QUICK_REPLIES_MAX) {
+    return {
+      valid: false,
+      error: `Quick replies exceed max of ${KAKAO_LIMITS.QUICK_REPLIES_MAX} (got ${replies.length})`,
+    };
+  }
+  for (let i = 0; i < replies.length; i++) {
+    const result = validateQuickReply(replies[i]);
+    if (!result.valid) {
+      return { valid: false, error: `Quick reply ${i}: ${result.error}` };
+    }
+  }
+  return { valid: true };
+}
+
+export function validateOutputCount(count: number): ValidationResult {
+  if (count > KAKAO_LIMITS.OUTPUTS_MAX) {
+    return {
+      valid: false,
+      error: `Outputs exceed max of ${KAKAO_LIMITS.OUTPUTS_MAX} (got ${count})`,
+    };
+  }
+  return { valid: true };
+}
+
+export function validateCarouselItemCount(count: number): ValidationResult {
+  if (count < KAKAO_LIMITS.CAROUSEL_MIN) {
+    return {
+      valid: false,
+      error: `Carousel requires at least ${KAKAO_LIMITS.CAROUSEL_MIN} items (got ${count})`,
+    };
+  }
+  if (count > KAKAO_LIMITS.CAROUSEL_MAX) {
+    return {
+      valid: false,
+      error: `Carousel exceeds max of ${KAKAO_LIMITS.CAROUSEL_MAX} items (got ${count})`,
+    };
+  }
+  return { valid: true };
+}
+
+export function validateListItemCount(count: number): ValidationResult {
+  if (count < KAKAO_LIMITS.LIST_ITEMS_MIN) {
+    return {
+      valid: false,
+      error: `List requires at least ${KAKAO_LIMITS.LIST_ITEMS_MIN} items (got ${count})`,
+    };
+  }
+  if (count > KAKAO_LIMITS.LIST_ITEMS_MAX) {
+    return {
+      valid: false,
+      error: `List exceeds max of ${KAKAO_LIMITS.LIST_ITEMS_MAX} items (got ${count})`,
+    };
+  }
+  return { valid: true };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -109,13 +109,19 @@ export interface KakaoThumbnail {
   fixedRatio?: boolean;
 }
 
+export interface KakaoOsLink {
+  ios?: string;
+  android?: string;
+}
+
 export interface KakaoButton {
   label: string;
-  action: "webLink" | "message" | "block" | "share" | "phone" | "operator";
+  action: "webLink" | "message" | "block" | "share" | "phone" | "operator" | "osLink";
   webLinkUrl?: string;
   messageText?: string;
   blockId?: string;
   phoneNumber?: string;
+  osLink?: KakaoOsLink;
   extra?: Record<string, unknown>;
 }
 

--- a/tests/unit/channel.test.ts
+++ b/tests/unit/channel.test.ts
@@ -26,7 +26,7 @@ describe("kakaoPlugin", () => {
   it("has correct capabilities", () => {
     expect(kakaoPlugin.capabilities).toEqual({
       chatTypes: ["direct"],
-      media: false,
+      media: true,
       threads: false,
       reactions: false,
       nativeCommands: false,

--- a/tests/unit/kakao/limits.test.ts
+++ b/tests/unit/kakao/limits.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect } from "vitest";
+import {
+  KAKAO_LIMITS,
+  validateSimpleText,
+  validateCardTitle,
+  validateCardDescription,
+  validateButton,
+  validateQuickReply,
+  validateQuickReplies,
+  validateOutputCount,
+  validateCarouselItemCount,
+  validateListItemCount,
+} from "../../../src/kakao/limits.js";
+
+describe("KAKAO_LIMITS constants", () => {
+  it("should have correct text limits", () => {
+    expect(KAKAO_LIMITS.SIMPLE_TEXT_MAX).toBe(1000);
+    expect(KAKAO_LIMITS.SIMPLE_TEXT_VISIBLE).toBe(400);
+  });
+
+  it("should have correct card limits", () => {
+    expect(KAKAO_LIMITS.CARD_TITLE).toBe(50);
+    expect(KAKAO_LIMITS.CARD_DESCRIPTION).toBe(230);
+  });
+
+  it("should have correct button/reply limits", () => {
+    expect(KAKAO_LIMITS.BUTTON_LABEL).toBe(14);
+    expect(KAKAO_LIMITS.QUICK_REPLY_LABEL).toBe(14);
+    expect(KAKAO_LIMITS.QUICK_REPLIES_MAX).toBe(10);
+  });
+
+  it("should have correct output/item limits", () => {
+    expect(KAKAO_LIMITS.OUTPUTS_MAX).toBe(3);
+    expect(KAKAO_LIMITS.CAROUSEL_MIN).toBe(2);
+    expect(KAKAO_LIMITS.CAROUSEL_MAX).toBe(10);
+    expect(KAKAO_LIMITS.LIST_ITEMS_MIN).toBe(2);
+    expect(KAKAO_LIMITS.LIST_ITEMS_MAX).toBe(5);
+  });
+});
+
+describe("validateSimpleText", () => {
+  it("should accept text within limit", () => {
+    expect(validateSimpleText("Hello")).toEqual({ valid: true });
+    expect(validateSimpleText("a".repeat(1000))).toEqual({ valid: true });
+  });
+
+  it("should reject text exceeding limit", () => {
+    const result = validateSimpleText("a".repeat(1001));
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error).toContain("1000");
+      expect(result.error).toContain("1001");
+    }
+  });
+});
+
+describe("validateCardTitle", () => {
+  it("should accept title within limit", () => {
+    expect(validateCardTitle("Short title")).toEqual({ valid: true });
+    expect(validateCardTitle("a".repeat(50))).toEqual({ valid: true });
+  });
+
+  it("should reject title exceeding limit", () => {
+    const result = validateCardTitle("a".repeat(51));
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error).toContain("50");
+    }
+  });
+});
+
+describe("validateCardDescription", () => {
+  it("should accept description within limit", () => {
+    expect(validateCardDescription("Short desc")).toEqual({ valid: true });
+    expect(validateCardDescription("a".repeat(230))).toEqual({ valid: true });
+  });
+
+  it("should reject description exceeding limit", () => {
+    const result = validateCardDescription("a".repeat(231));
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error).toContain("230");
+    }
+  });
+});
+
+describe("validateButton", () => {
+  it("should accept button with valid label", () => {
+    expect(validateButton({ label: "Click me", action: "message" })).toEqual({ valid: true });
+    expect(validateButton({ label: "a".repeat(14), action: "webLink" })).toEqual({ valid: true });
+  });
+
+  it("should reject button with label exceeding limit", () => {
+    const result = validateButton({ label: "a".repeat(15), action: "message" });
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error).toContain("14");
+    }
+  });
+});
+
+describe("validateQuickReply", () => {
+  it("should accept quick reply with valid label", () => {
+    expect(validateQuickReply({ label: "Yes", action: "message" })).toEqual({ valid: true });
+  });
+
+  it("should reject quick reply with label exceeding limit", () => {
+    const result = validateQuickReply({ label: "a".repeat(15), action: "message" });
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error).toContain("14");
+    }
+  });
+});
+
+describe("validateQuickReplies", () => {
+  it("should accept array within limit", () => {
+    const replies = Array(10).fill(null).map((_, i) => ({ label: `Option ${i}`, action: "message" as const }));
+    expect(validateQuickReplies(replies)).toEqual({ valid: true });
+  });
+
+  it("should reject array exceeding max count", () => {
+    const replies = Array(11).fill(null).map((_, i) => ({ label: `O${i}`, action: "message" as const }));
+    const result = validateQuickReplies(replies);
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error).toContain("10");
+    }
+  });
+
+  it("should reject if any reply has invalid label", () => {
+    const replies = [
+      { label: "Valid", action: "message" as const },
+      { label: "a".repeat(15), action: "message" as const },
+    ];
+    const result = validateQuickReplies(replies);
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error).toContain("Quick reply 1");
+    }
+  });
+});
+
+describe("validateOutputCount", () => {
+  it("should accept count within limit", () => {
+    expect(validateOutputCount(1)).toEqual({ valid: true });
+    expect(validateOutputCount(3)).toEqual({ valid: true });
+  });
+
+  it("should reject count exceeding limit", () => {
+    const result = validateOutputCount(4);
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error).toContain("3");
+    }
+  });
+});
+
+describe("validateCarouselItemCount", () => {
+  it("should accept count within range", () => {
+    expect(validateCarouselItemCount(2)).toEqual({ valid: true });
+    expect(validateCarouselItemCount(10)).toEqual({ valid: true });
+  });
+
+  it("should reject count below minimum", () => {
+    const result = validateCarouselItemCount(1);
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error).toContain("at least 2");
+    }
+  });
+
+  it("should reject count above maximum", () => {
+    const result = validateCarouselItemCount(11);
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error).toContain("max of 10");
+    }
+  });
+});
+
+describe("validateListItemCount", () => {
+  it("should accept count within range", () => {
+    expect(validateListItemCount(2)).toEqual({ valid: true });
+    expect(validateListItemCount(5)).toEqual({ valid: true });
+  });
+
+  it("should reject count below minimum", () => {
+    const result = validateListItemCount(1);
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error).toContain("at least 2");
+    }
+  });
+
+  it("should reject count above maximum", () => {
+    const result = validateListItemCount(6);
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error).toContain("max of 5");
+    }
+  });
+});

--- a/tests/unit/types.test.ts
+++ b/tests/unit/types.test.ts
@@ -1,14 +1,11 @@
-/**
- * Type definition tests - verify type exports and structure
- */
 import { describe, it, expect } from "vitest";
 import type {
   KakaoSkillPayload,
   KakaoSkillResponse,
-  KakaoAccountConfig,
-  ResolvedKakaoAccount,
-  KakaoSimpleText,
-  KakaoOutput,
+  KakaoChannelConfig,
+  ResolvedKakaoTalkChannel,
+  KakaoButton,
+  KakaoOsLink,
   InboundMessage,
 } from "../../src/types";
 
@@ -83,46 +80,65 @@ describe("Kakao Types", () => {
     });
   });
 
-  describe("KakaoAccountConfig", () => {
+  describe("KakaoChannelConfig", () => {
     it("should have required fields", () => {
-      const config: KakaoAccountConfig = {
+      const config: KakaoChannelConfig = {
         enabled: true,
-        channelId: "channel123",
-        mode: "direct",
         dmPolicy: "pairing",
       };
-      expect(config.mode).toBe("direct");
+      expect(config.enabled).toBe(true);
     });
 
     it("should support relay mode fields", () => {
-      const config: KakaoAccountConfig = {
+      const config: KakaoChannelConfig = {
         enabled: true,
         channelId: "channel123",
-        mode: "relay",
         dmPolicy: "pairing",
         relayUrl: "https://relay.example.com",
         relayToken: "token123",
-        reconnectDelayMs: 1000,
-        maxReconnectDelayMs: 30000,
       };
       expect(config.relayUrl).toBeDefined();
     });
   });
 
-  describe("ResolvedKakaoAccount", () => {
-    it("should contain accountId and config", () => {
-      const resolved: ResolvedKakaoAccount = {
-        accountId: "default",
+  describe("ResolvedKakaoTalkChannel", () => {
+    it("should contain talkchannelId and config", () => {
+      const resolved: ResolvedKakaoTalkChannel = {
+        talkchannelId: "default",
         config: {
           enabled: true,
-          channelId: "ch1",
-          mode: "direct",
           dmPolicy: "pairing",
         },
         enabled: true,
         name: "Test Account",
       };
-      expect(resolved.accountId).toBe("default");
+      expect(resolved.talkchannelId).toBe("default");
+    });
+  });
+
+  describe("KakaoButton", () => {
+    it("should support all button actions", () => {
+      const actions: KakaoButton["action"][] = [
+        "webLink", "message", "block", "share", "phone", "operator", "osLink"
+      ];
+      actions.forEach(action => {
+        const button: KakaoButton = { label: "Test", action };
+        expect(button.action).toBe(action);
+      });
+    });
+
+    it("should support osLink with platform-specific URLs", () => {
+      const osLink: KakaoOsLink = {
+        ios: "kakaomap://route?sp=37.5,127.0",
+        android: "intent://route?sp=37.5,127.0#Intent;scheme=kakaomap;end",
+      };
+      const button: KakaoButton = {
+        label: "지도에서 보기",
+        action: "osLink",
+        osLink,
+      };
+      expect(button.osLink?.ios).toContain("kakaomap");
+      expect(button.osLink?.android).toContain("intent");
     });
   });
 
@@ -130,15 +146,14 @@ describe("Kakao Types", () => {
     it("should match relay server spec", () => {
       const msg: InboundMessage = {
         id: "msg_123",
-        timestamp: Date.now(),
+        conversationKey: "conv_123",
         kakaoPayload: {} as KakaoSkillPayload,
         normalized: {
           userId: "user1",
           text: "Hello",
           channelId: "ch1",
         },
-        callbackUrl: "https://bot-api.kakao.com/callback/xxx",
-        callbackExpiresAt: Date.now() + 60000,
+        createdAt: new Date().toISOString(),
       };
       expect(msg.normalized.userId).toBe("user1");
     });


### PR DESCRIPTION
## Summary

- Fix `capabilities.media` to `true` (we support `simpleImage`)
- Add `osLink` button action type with deep link support
- Add validation constants and functions for all Kakao API limits

## Changes

### #9: capabilities.media fix

```typescript
// Before
capabilities: { media: false, ... }

// After  
capabilities: { media: true, ... }
```

### #6: osLink button action

```typescript
export interface KakaoOsLink {
  ios?: string;
  android?: string;
}

export interface KakaoButton {
  action: "webLink" | "message" | "block" | "share" | "phone" | "operator" | "osLink";
  osLink?: KakaoOsLink;
  // ...
}
```

### #7: Validation constants & functions

New file: `src/kakao/limits.ts`

```typescript
export const KAKAO_LIMITS = {
  SIMPLE_TEXT_MAX: 1000,
  SIMPLE_TEXT_VISIBLE: 400,
  CARD_TITLE: 50,
  CARD_DESCRIPTION: 230,
  BUTTON_LABEL: 14,
  QUICK_REPLY_LABEL: 14,
  QUICK_REPLIES_MAX: 10,
  OUTPUTS_MAX: 3,
  CAROUSEL_MIN: 2,
  CAROUSEL_MAX: 10,
  LIST_ITEMS_MIN: 2,
  LIST_ITEMS_MAX: 5,
} as const;

// Validation functions
validateSimpleText(text)
validateCardTitle(title)
validateCardDescription(description)
validateButton(button)
validateQuickReply(reply)
validateQuickReplies(replies)
validateOutputCount(count)
validateCarouselItemCount(count)
validateListItemCount(count)
```

## Testing

All 423 tests pass including 25 new tests for validation functions.

## Closes

- #9 (capabilities.media를 true로 변경)
- #6 (osLink 버튼 액션 타입 추가)
- #7 (문자 제한 상수 및 검증 함수 추가)