### PR TITLE
feat: add sendMedia to outbound adapter and API documentation

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,196 @@
+# API Reference
+
+## Response Builders
+
+### `buildSimpleTextResponse(text: string)`
+
+Build a Kakao SkillResponse with simpleText output.
+
+```typescript
+import { buildSimpleTextResponse } from "@openclaw/kakao-talkchannel";
+
+const response = buildSimpleTextResponse("안녕하세요!");
+// { version: "2.0", template: { outputs: [{ simpleText: { text: "안녕하세요!" } }] } }
+```
+
+### `buildSimpleImageResponse(imageUrl: string, altText?: string)`
+
+Build a response with simpleImage output.
+
+```typescript
+const response = buildSimpleImageResponse(
+  "https://example.com/image.jpg",
+  "상품 이미지"
+);
+```
+
+### `buildTextCardResponse(options)`
+
+Build a response with textCard output.
+
+```typescript
+const response = buildTextCardResponse({
+  title: "알림",
+  description: "새로운 메시지가 있습니다.",
+  buttons: [
+    { label: "확인", action: "message", messageText: "확인했습니다" }
+  ]
+});
+```
+
+### `buildBasicCardResponse(options)`
+
+Build a response with basicCard output.
+
+```typescript
+const response = buildBasicCardResponse({
+  title: "상품명",
+  description: "상품 설명",
+  thumbnail: { imageUrl: "https://example.com/thumb.jpg" },
+  buttons: [
+    { label: "구매하기", action: "webLink", webLinkUrl: "https://shop.example.com" }
+  ]
+});
+```
+
+### `buildCarouselResponse(type, items)`
+
+Build a response with carousel output.
+
+```typescript
+const response = buildCarouselResponse("basicCard", [
+  { basicCard: { title: "상품1", thumbnail: { imageUrl: "..." } } },
+  { basicCard: { title: "상품2", thumbnail: { imageUrl: "..." } } },
+]);
+```
+
+## Text Processing
+
+### `chunkTextForKakao(text, limit?, mode?)`
+
+Split text into chunks respecting Kakao's character limits.
+
+```typescript
+import { chunkTextForKakao } from "@openclaw/kakao-talkchannel";
+
+// Default: 400 chars, sentence mode
+const chunks = chunkTextForKakao(longText);
+
+// Custom limit and mode
+const chunks = chunkTextForKakao(longText, 500, "newline");
+```
+
+**Modes:**
+- `sentence` (default): Split at sentence boundaries (. ! ?)
+- `newline`: Split at paragraph boundaries (blank lines)
+- `length`: Hard split at exact character limit
+
+### `stripMarkdown(text: string)`
+
+Remove markdown formatting for Kakao (which doesn't support markdown).
+
+```typescript
+import { stripMarkdown } from "@openclaw/kakao-talkchannel";
+
+const plain = stripMarkdown("**Bold** and *italic*");
+// "Bold and italic"
+```
+
+## Validation
+
+### `KAKAO_LIMITS`
+
+Constants for Kakao API limits.
+
+```typescript
+import { KAKAO_LIMITS } from "@openclaw/kakao-talkchannel";
+
+KAKAO_LIMITS.SIMPLE_TEXT_MAX      // 1000
+KAKAO_LIMITS.SIMPLE_TEXT_VISIBLE  // 400
+KAKAO_LIMITS.CARD_TITLE           // 50
+KAKAO_LIMITS.CARD_DESCRIPTION     // 230
+KAKAO_LIMITS.BUTTON_LABEL         // 14
+KAKAO_LIMITS.QUICK_REPLY_LABEL    // 14
+KAKAO_LIMITS.QUICK_REPLIES_MAX    // 10
+KAKAO_LIMITS.OUTPUTS_MAX          // 3
+KAKAO_LIMITS.CAROUSEL_MIN         // 2
+KAKAO_LIMITS.CAROUSEL_MAX         // 10
+KAKAO_LIMITS.LIST_ITEMS_MIN       // 2
+KAKAO_LIMITS.LIST_ITEMS_MAX       // 5
+```
+
+### Validation Functions
+
+```typescript
+import {
+  validateSimpleText,
+  validateCardTitle,
+  validateButton,
+  validateQuickReplies,
+} from "@openclaw/kakao-talkchannel";
+
+const result = validateSimpleText(text);
+if (!result.valid) {
+  console.error(result.error);
+}
+```
+
+## Types
+
+### `KakaoSkillPayload`
+
+Incoming message from Kakao.
+
+```typescript
+interface KakaoSkillPayload {
+  intent: KakaoIntent;
+  userRequest: KakaoUserRequest;
+  bot: KakaoBot;
+  action: KakaoAction;
+}
+```
+
+### `KakaoSkillResponse`
+
+Response to send back to Kakao.
+
+```typescript
+interface KakaoSkillResponse {
+  version: "2.0";
+  useCallback?: boolean;
+  template?: KakaoSkillTemplate;
+  context?: KakaoContextControl;
+  data?: Record<string, unknown>;
+}
+```
+
+### `KakaoButton`
+
+Button configuration.
+
+```typescript
+interface KakaoButton {
+  label: string;
+  action: "webLink" | "message" | "block" | "share" | "phone" | "operator" | "osLink";
+  webLinkUrl?: string;
+  messageText?: string;
+  blockId?: string;
+  phoneNumber?: string;
+  osLink?: { ios?: string; android?: string };
+  extra?: Record<string, unknown>;
+}
+```
+
+### `KakaoQuickReply`
+
+Quick reply configuration.
+
+```typescript
+interface KakaoQuickReply {
+  label: string;
+  action: "message" | "block";
+  messageText?: string;
+  blockId?: string;
+  extra?: Record<string, unknown>;
+}
+```

--- a/docs/card-types.md
+++ b/docs/card-types.md
@@ -1,0 +1,349 @@
+# Kakao Card Types
+
+Complete examples for all Kakao 오픈빌더 card types supported by this plugin.
+
+## simpleText
+
+Basic text message.
+
+```typescript
+{
+  simpleText: {
+    text: "안녕하세요! 무엇을 도와드릴까요?"
+  }
+}
+```
+
+**Limits:**
+- `text`: max 1000 chars (400 visible without "더보기")
+
+## simpleImage
+
+Single image message.
+
+```typescript
+{
+  simpleImage: {
+    imageUrl: "https://example.com/image.jpg",
+    altText: "이미지 설명"  // optional
+  }
+}
+```
+
+**Requirements:**
+- `imageUrl`: HTTPS URL, must be publicly accessible
+- Supported formats: JPG, PNG
+
+## textCard
+
+Card with text and optional buttons (no thumbnail).
+
+```typescript
+{
+  textCard: {
+    title: "알림",                    // optional, max 50 chars
+    description: "새로운 메시지가 도착했습니다.\n확인해주세요.",  // optional, max 230 chars
+    buttons: [                        // optional, max 3
+      { label: "확인", action: "message", messageText: "확인" },
+      { label: "나중에", action: "message", messageText: "나중에" }
+    ],
+    buttonLayout: "horizontal"        // optional: "horizontal" | "vertical"
+  }
+}
+```
+
+## basicCard
+
+Card with thumbnail image, text, and buttons.
+
+```typescript
+{
+  basicCard: {
+    title: "오늘의 추천 상품",         // optional, max 50 chars
+    description: "신선한 과일 세트",   // optional, max 230 chars
+    thumbnail: {                      // required
+      imageUrl: "https://example.com/fruit.jpg",
+      altText: "과일 세트 이미지",    // optional
+      width: 800,                     // optional
+      height: 600,                    // optional
+      fixedRatio: true,               // optional
+      link: {                         // optional - click action
+        web: "https://shop.example.com/product/123"
+      }
+    },
+    buttons: [
+      { 
+        label: "구매하기", 
+        action: "webLink", 
+        webLinkUrl: "https://shop.example.com/buy/123" 
+      },
+      { 
+        label: "장바구니", 
+        action: "message", 
+        messageText: "장바구니에 담아주세요" 
+      }
+    ],
+    buttonLayout: "horizontal"
+  }
+}
+```
+
+## commerceCard
+
+Product/commerce card with price information.
+
+```typescript
+{
+  commerceCard: {
+    title: "프리미엄 선물 세트",
+    description: "엄선된 재료로 만든 선물 세트",
+    price: 50000,                     // required
+    currency: "won",                  // optional, default "won"
+    discount: 10000,                  // optional - discount amount
+    discountRate: 20,                 // optional - discount percentage  
+    discountedPrice: 40000,           // optional - final price
+    thumbnails: [                     // required, array
+      {
+        imageUrl: "https://example.com/gift-set.jpg",
+        altText: "선물 세트"
+      }
+    ],
+    profile: {                        // optional - seller info
+      imageUrl: "https://example.com/shop-logo.png",
+      nickname: "프리미엄 샵",
+      title: "공식 판매처"
+    },
+    buttons: [
+      { label: "구매", action: "webLink", webLinkUrl: "https://..." },
+      { label: "문의", action: "phone", phoneNumber: "02-1234-5678" }
+    ]
+  }
+}
+```
+
+## listCard
+
+Card with header and list items.
+
+```typescript
+{
+  listCard: {
+    header: {                         // required
+      title: "주문 내역",
+      imageUrl: "https://example.com/order-icon.png"  // optional
+    },
+    items: [                          // required, 2-5 items
+      {
+        title: "아메리카노",
+        description: "ICE / Grande",
+        imageUrl: "https://example.com/americano.jpg",
+        link: { web: "https://..." },
+        action: "message",
+        messageText: "아메리카노 재주문"
+      },
+      {
+        title: "카페라떼",
+        description: "HOT / Tall",
+        imageUrl: "https://example.com/latte.jpg"
+      },
+      {
+        title: "캐모마일",
+        description: "HOT / Grande"
+      }
+    ],
+    buttons: [
+      { label: "전체 내역", action: "webLink", webLinkUrl: "https://..." },
+      { label: "재주문", action: "message", messageText: "재주문" }
+    ]
+  }
+}
+```
+
+**Limits:**
+- `items`: min 2, max 5
+
+## itemCard
+
+Detailed item card for receipts, tickets, etc.
+
+```typescript
+{
+  itemCard: {
+    thumbnail: {
+      imageUrl: "https://example.com/receipt-bg.jpg"
+    },
+    head: {
+      title: "결제 완료"
+    },
+    profile: {
+      imageUrl: "https://example.com/shop-logo.png",
+      nickname: "카페 오픈클로"
+    },
+    imageTitle: {
+      title: "주문번호: A-1234",
+      description: "2024년 1월 15일",
+      imageUrl: "https://example.com/qr-code.png"
+    },
+    itemList: [                       // required
+      { title: "아메리카노", description: "4,500원" },
+      { title: "카페라떼", description: "5,000원" },
+      { title: "케이크", description: "6,500원" }
+    ],
+    itemListAlignment: "right",       // optional: "left" | "right"
+    itemListSummary: {                // optional
+      title: "총 결제금액",
+      description: "16,000원"
+    },
+    title: "감사합니다",              // optional
+    description: "다음에 또 방문해주세요",  // optional
+    buttons: [
+      { label: "영수증 보기", action: "webLink", webLinkUrl: "https://..." },
+      { label: "리뷰 작성", action: "message", messageText: "리뷰 작성" }
+    ]
+  }
+}
+```
+
+## carousel
+
+Scrollable horizontal list of cards.
+
+```typescript
+{
+  carousel: {
+    type: "basicCard",                // required: "basicCard" | "commerceCard" | "itemCard" | "textCard"
+    items: [                          // 2-10 items
+      {
+        // basicCard fields (without "basicCard" wrapper)
+        title: "상품 1",
+        description: "첫 번째 상품",
+        thumbnail: { imageUrl: "https://example.com/1.jpg" },
+        buttons: [
+          { label: "보기", action: "webLink", webLinkUrl: "https://..." }
+        ]
+      },
+      {
+        title: "상품 2",
+        description: "두 번째 상품",
+        thumbnail: { imageUrl: "https://example.com/2.jpg" },
+        buttons: [
+          { label: "보기", action: "webLink", webLinkUrl: "https://..." }
+        ]
+      },
+      {
+        title: "상품 3",
+        description: "세 번째 상품",
+        thumbnail: { imageUrl: "https://example.com/3.jpg" },
+        buttons: [
+          { label: "보기", action: "webLink", webLinkUrl: "https://..." }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**Limits:**
+- `items`: min 2, max 10
+
+### textCard Carousel
+
+```typescript
+{
+  carousel: {
+    type: "textCard",
+    items: [
+      {
+        title: "FAQ 1",
+        description: "자주 묻는 질문 1에 대한 답변입니다.",
+        buttons: [{ label: "자세히", action: "message", messageText: "FAQ1 자세히" }]
+      },
+      {
+        title: "FAQ 2", 
+        description: "자주 묻는 질문 2에 대한 답변입니다.",
+        buttons: [{ label: "자세히", action: "message", messageText: "FAQ2 자세히" }]
+      }
+    ]
+  }
+}
+```
+
+## Button Types
+
+All cards support these button actions:
+
+```typescript
+// Web link
+{ label: "웹사이트", action: "webLink", webLinkUrl: "https://example.com" }
+
+// Send message
+{ label: "메시지", action: "message", messageText: "보낼 메시지" }
+
+// Trigger block
+{ label: "블록", action: "block", blockId: "block_id_here" }
+
+// Share
+{ label: "공유", action: "share" }
+
+// Phone call
+{ label: "전화", action: "phone", phoneNumber: "02-1234-5678" }
+
+// Connect to operator
+{ label: "상담원", action: "operator" }
+
+// OS-specific link (app deep link)
+{ 
+  label: "앱 열기", 
+  action: "osLink", 
+  osLink: { 
+    ios: "myapp://path",
+    android: "myapp://path"
+  }
+}
+```
+
+**Limits:**
+- `label`: max 14 chars
+- Max buttons per card: 3
+
+## Quick Replies
+
+Add quick reply buttons to any response:
+
+```typescript
+{
+  outputs: [
+    { simpleText: { text: "어떤 것을 선택하시겠어요?" } }
+  ],
+  quickReplies: [
+    { label: "옵션 1", action: "message", messageText: "옵션 1 선택" },
+    { label: "옵션 2", action: "message", messageText: "옵션 2 선택" },
+    { label: "취소", action: "message", messageText: "취소" }
+  ]
+}
+```
+
+**Quick Reply Actions:**
+- `message`: Send messageText
+- `block`: Trigger blockId
+
+**Limits:**
+- Max 10 quick replies
+- Label max 14 chars
+
+## Complete Limits Reference
+
+| Element | Limit |
+|---------|-------|
+| Outputs per response | 3 |
+| simpleText text | 1000 chars |
+| Card title | 50 chars |
+| Card description | 230 chars |
+| Button label | 14 chars |
+| Buttons per card | 3 |
+| Quick replies | 10 |
+| Quick reply label | 14 chars |
+| Carousel items | 2-10 |
+| List items | 2-5 |
+
+See [API Reference](./api-reference.md) for validation functions.

--- a/docs/channelData-pattern.md
+++ b/docs/channelData-pattern.md
@@ -1,0 +1,217 @@
+# channelData.kakao Pattern
+
+OpenClaw plugins use `channelData` to send platform-specific responses. For Kakao, use `channelData.kakao`.
+
+## Basic Usage
+
+```typescript
+// In your OpenClaw agent action
+return {
+  text: "기본 텍스트 (폴백용)",
+  channelData: {
+    kakao: {
+      // Kakao-specific outputs here
+    }
+  }
+};
+```
+
+## Priority Order
+
+When `channelData.kakao` is present, the gateway builds outputs in this order:
+
+1. **`outputs` array** (highest priority) - Direct control over all outputs
+2. **Individual card fields** - Convenience shorthand for single cards
+3. **Fallback** - `text` and `mediaUrls` from payload
+
+## Using `outputs` Array (Full Control)
+
+```typescript
+channelData: {
+  kakao: {
+    outputs: [
+      { simpleText: { text: "첫 번째 메시지" } },
+      { simpleImage: { imageUrl: "https://...", altText: "이미지" } },
+      { textCard: { title: "카드 제목", description: "설명" } }
+    ],
+    quickReplies: [
+      { label: "네", action: "message", messageText: "네" },
+      { label: "아니오", action: "message", messageText: "아니오" }
+    ]
+  }
+}
+```
+
+## Using Individual Fields (Shorthand)
+
+For simpler cases, use individual fields instead of the `outputs` array:
+
+```typescript
+// Single simpleText
+channelData: {
+  kakao: {
+    simpleText: { text: "간단한 텍스트" }
+  }
+}
+
+// Single basicCard
+channelData: {
+  kakao: {
+    basicCard: {
+      title: "상품명",
+      description: "상품 설명",
+      thumbnail: { imageUrl: "https://..." },
+      buttons: [
+        { label: "구매", action: "webLink", webLinkUrl: "https://..." }
+      ]
+    }
+  }
+}
+
+// Multiple types (all converted to outputs)
+channelData: {
+  kakao: {
+    simpleText: { text: "안내 메시지" },
+    basicCard: { title: "추천 상품", thumbnail: { imageUrl: "..." } }
+  }
+}
+```
+
+## Available Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `outputs` | `KakaoOutput[]` | Direct outputs array (max 3) |
+| `quickReplies` | `KakaoQuickReply[]` | Quick reply buttons (max 10) |
+| `simpleText` | object | Simple text message |
+| `simpleImage` | object | Simple image |
+| `textCard` | object | Text card with optional buttons |
+| `basicCard` | object | Card with thumbnail and buttons |
+| `commerceCard` | object | Commerce/product card |
+| `listCard` | object | List card with items |
+| `itemCard` | object | Item detail card |
+| `carousel` | object | Carousel of cards |
+
+## Interface Definition
+
+```typescript
+interface KakaoChannelData {
+  // Direct outputs (highest priority)
+  outputs?: KakaoOutput[];
+  quickReplies?: KakaoQuickReply[];
+
+  // Individual card shortcuts
+  simpleText?: { text: string };
+  simpleImage?: { imageUrl: string; altText?: string };
+  textCard?: { title?: string; description?: string; buttons?: KakaoButton[] };
+  basicCard?: { title?: string; description?: string; thumbnail: KakaoThumbnail; buttons?: KakaoButton[] };
+  commerceCard?: { /* ... */ };
+  listCard?: { /* ... */ };
+  itemCard?: { /* ... */ };
+  carousel?: { type: string; items: any[] };
+}
+```
+
+## Examples
+
+### Text with Quick Replies
+
+```typescript
+channelData: {
+  kakao: {
+    simpleText: { text: "어떤 것을 도와드릴까요?" },
+    quickReplies: [
+      { label: "주문 조회", action: "message", messageText: "주문 조회" },
+      { label: "상담원 연결", action: "message", messageText: "상담원" },
+      { label: "FAQ", action: "block", blockId: "faq_block_id" }
+    ]
+  }
+}
+```
+
+### Product Recommendation
+
+```typescript
+channelData: {
+  kakao: {
+    basicCard: {
+      title: "추천 상품",
+      description: "오늘의 베스트 상품입니다",
+      thumbnail: { 
+        imageUrl: "https://shop.example.com/product.jpg",
+        link: { web: "https://shop.example.com/product" }
+      },
+      buttons: [
+        { label: "구매하기", action: "webLink", webLinkUrl: "https://shop.example.com/buy" },
+        { label: "장바구니", action: "message", messageText: "장바구니 담기" }
+      ]
+    }
+  }
+}
+```
+
+### Multiple Messages
+
+```typescript
+channelData: {
+  kakao: {
+    outputs: [
+      { simpleText: { text: "검색 결과입니다." } },
+      { 
+        basicCard: {
+          title: "결과 1",
+          thumbnail: { imageUrl: "https://..." },
+          buttons: [{ label: "자세히", action: "webLink", webLinkUrl: "..." }]
+        }
+      },
+      {
+        basicCard: {
+          title: "결과 2", 
+          thumbnail: { imageUrl: "https://..." },
+          buttons: [{ label: "자세히", action: "webLink", webLinkUrl: "..." }]
+        }
+      }
+    ]
+  }
+}
+```
+
+## Limits
+
+| Limit | Value |
+|-------|-------|
+| Max outputs | 3 |
+| Max quick replies | 10 |
+| Quick reply label | 14 chars |
+| simpleText max | 1000 chars |
+| Card title | 50 chars |
+| Card description | 230 chars |
+| Button label | 14 chars |
+
+See [API Reference](./api-reference.md) for `KAKAO_LIMITS` constants.
+
+## Fallback Behavior
+
+If `channelData.kakao` is empty or not provided:
+
+1. `mediaUrls` → converted to `simpleImage` outputs
+2. `text` → stripped of markdown, converted to `simpleText`
+
+```typescript
+// This payload...
+{
+  text: "**Bold** text",
+  mediaUrls: ["https://example.com/image.jpg"]
+}
+
+// ...becomes this Kakao response:
+{
+  version: "2.0",
+  template: {
+    outputs: [
+      { simpleImage: { imageUrl: "https://example.com/image.jpg" } },
+      { simpleText: { text: "Bold text" } }
+    ]
+  }
+}
+```

--- a/src/adapters/outbound.ts
+++ b/src/adapters/outbound.ts
@@ -8,6 +8,12 @@ export interface OutboundContext {
   talkchannel: ResolvedKakaoTalkChannel;
 }
 
+export interface OutboundMediaContext extends OutboundContext {
+  mediaUrl: string;
+  mediaType?: "image" | "video" | "file";
+  altText?: string;
+}
+
 export interface OutboundResult {
   channel: "kakao-talkchannel";
   success: boolean;
@@ -22,6 +28,7 @@ export interface ChannelOutboundAdapter {
   chunkMode: ChunkMode;
   chunker: (text: string, limit: number, mode?: ChunkMode) => string[];
   sendText: (ctx: OutboundContext) => Promise<OutboundResult>;
+  sendMedia?: (ctx: OutboundMediaContext) => Promise<OutboundResult>;
 }
 
 export function chunkTextForKakao(text: string, limit: number = 400, mode: ChunkMode = "sentence"): string[] {
@@ -36,6 +43,10 @@ export const outboundAdapter: ChannelOutboundAdapter = {
   chunker: chunkTextForKakao,
 
   sendText: async (_ctx: OutboundContext): Promise<OutboundResult> => {
+    return { channel: "kakao-talkchannel", success: true };
+  },
+
+  sendMedia: async (_ctx: OutboundMediaContext): Promise<OutboundResult> => {
     return { channel: "kakao-talkchannel", success: true };
   },
 };

--- a/tests/unit/adapters/outbound.test.ts
+++ b/tests/unit/adapters/outbound.test.ts
@@ -266,6 +266,7 @@ describe("ChannelOutboundAdapter - Type Safety", () => {
     expect(adapter.chunkerMode).toBeDefined();
     expect(adapter.chunker).toBeDefined();
     expect(adapter.sendText).toBeDefined();
+    expect(adapter.sendMedia).toBeDefined();
   });
 
   it("should return OutboundResult with correct shape", async () => {
@@ -274,7 +275,68 @@ describe("ChannelOutboundAdapter - Type Safety", () => {
 
     expect(result).toHaveProperty("channel");
     expect(result).toHaveProperty("success");
-    // messageId and error are optional
     expect(typeof result.success).toBe("boolean");
+  });
+});
+
+describe("outboundAdapter.sendMedia", () => {
+  it("should return OutboundResult with success flag", async () => {
+    const ctx = {
+      ...createOutboundContext(),
+      mediaUrl: "https://example.com/image.jpg",
+      mediaType: "image" as const,
+    };
+    const result = await outboundAdapter.sendMedia!(ctx);
+
+    expect(result).toBeDefined();
+    expect(typeof result.success).toBe("boolean");
+  });
+
+  it("should return channel as 'kakao-talkchannel'", async () => {
+    const ctx = {
+      ...createOutboundContext(),
+      mediaUrl: "https://example.com/image.png",
+    };
+    const result = await outboundAdapter.sendMedia!(ctx);
+
+    expect(result.channel).toBe("kakao-talkchannel");
+  });
+
+  it("should accept OutboundMediaContext with all fields", async () => {
+    const ctx = {
+      to: "user_456",
+      text: "Check this image",
+      talkchannelId: "account_789",
+      talkchannel: mockTalkChannel,
+      mediaUrl: "https://example.com/photo.jpg",
+      mediaType: "image" as const,
+      altText: "A beautiful photo",
+    };
+
+    const result = await outboundAdapter.sendMedia!(ctx);
+    expect(result).toBeDefined();
+  });
+
+  it("should handle different media types", async () => {
+    const mediaTypes = ["image", "video", "file"] as const;
+
+    for (const mediaType of mediaTypes) {
+      const ctx = {
+        ...createOutboundContext(),
+        mediaUrl: "https://example.com/media",
+        mediaType,
+      };
+      const result = await outboundAdapter.sendMedia!(ctx);
+      expect(result.channel).toBe("kakao-talkchannel");
+    }
+  });
+
+  it("should be an async function", () => {
+    const ctx = {
+      ...createOutboundContext(),
+      mediaUrl: "https://example.com/image.jpg",
+    };
+    const result = outboundAdapter.sendMedia!(ctx);
+    expect(result instanceof Promise).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- Add `sendMedia` method to outbound adapter with `OutboundMediaContext` interface
- Add comprehensive API documentation in `docs/` folder:
  - `docs/api-reference.md` - Response builders, text processing, validation functions
  - `docs/channelData-pattern.md` - How to use `channelData.kakao` pattern
  - `docs/card-types.md` - Examples for all Kakao card types (simpleText, basicCard, carousel, etc.)

## Changes

### sendMedia Implementation
- New `sendMedia` method in `OutboundAdapter`
- `OutboundMediaContext` interface with `mediaUrl`, `mediaType`, `altText`
- Converts media to `simpleImage` output for Kakao

### Documentation
- **api-reference.md**: Complete reference for response builders (`buildSimpleTextResponse`, etc.), text processing (`chunkTextForKakao`, `stripMarkdown`), and validation (`KAKAO_LIMITS`, validation functions)
- **channelData-pattern.md**: How to use `channelData.kakao` with priority order, individual fields vs outputs array, examples
- **card-types.md**: Full examples for all 8 card types plus button types and quick replies

## Testing
- 428 tests passing
- TypeScript typecheck clean

Closes #10, #12