### PR TITLE
fix(security): 토큰 상태 마스킹 및 보안 체크리스트

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,30 @@ openclaw plugins install {경로}
 
 ---
 
+## 보안
+
+### 토큰 관리
+
+- `relayToken`과 `sessionToken`은 민감 정보로 취급됩니다 (`sensitive: true`)
+- 환경변수 `OPENCLAW_TALKCHANNEL_RELAY_TOKEN` 사용을 권장합니다
+- 설정 파일에 토큰을 직접 기록할 경우 파일 권한에 주의하세요
+
+### 릴레이 서버 URL
+
+- `relayUrl`에는 **HTTPS URL만 사용**하세요
+- 내부 네트워크 주소(예: `localhost`, `127.0.0.1`, `10.x.x.x`)를 릴레이 URL로 사용하지 마세요
+- 자체 릴레이 서버 배포 시 공인 HTTPS 엔드포인트를 사용하세요
+
+### OpenClaw 보안 스캐너
+
+이 플러그인은 OpenClaw v2026.2.1+ 보안 스캐너와 호환됩니다:
+
+- `eval()`, `Function()` 등 동적 코드 실행 없음
+- 민감 필드에 `sensitive: true` 표시 (`openclaw.plugin.json`)
+- health check 응답에서 토큰 값을 노출하지 않음
+
+---
+
 ## 라이선스
 
 MIT

--- a/src/adapters/gateway.ts
+++ b/src/adapters/gateway.ts
@@ -591,7 +591,7 @@ async function handleRelayCommand(
       const responseTime = Date.now() - startTime;
       status = "✅ 정상";
       latency = `${responseTime}ms`;
-      sessionStatus = relayToken ? "페어링 완료" : "토큰 없음";
+      sessionStatus = "연결됨";
     } else {
       status = `⚠️ HTTP ${healthResponse.status}`;
     }
@@ -655,12 +655,13 @@ async function handleSessionCommand(
   const messageCount = activity?.messageCount || 0;
   const lastWarningCount = activity?.lastWarningCount || 0;
 
-  // 간단한 세션 정보
+  // 간단한 세션 정보 (토큰 존재 여부를 직접 노출하지 않음)
+  const connectionStatus = relayToken ? "✅" : "⚠️ 미연결";
   const sessionInfo =
     `메시지: ${messageCount}개\n` +
     `마지막 경고: ${lastWarningCount > 0 ? lastWarningCount + '개 시점' : '없음'}\n` +
     `페어링: ✅ ${userId}\n` +
-    `토큰: ${relayToken ? '연결됨' : '없음'}`;
+    `연결: ${connectionStatus}`;
 
   const response: KakaoSkillResponse = {
     version: "2.0",

--- a/tests/unit/security/plugin-safety.test.ts
+++ b/tests/unit/security/plugin-safety.test.ts
@@ -1,0 +1,123 @@
+/**
+ * 플러그인 보안 체크리스트 테스트
+ *
+ * OpenClaw v2026.2.1+ 보안 스캐너 호환성 확인.
+ * 플러그인 소스 코드에 위험 패턴이 없는지 정적 분석.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync, statSync } from "fs";
+import { join } from "path";
+
+const SRC_DIR = join(__dirname, "../../../src");
+
+/** src/ 하위의 모든 .ts 파일을 재귀 수집 */
+function collectTsFiles(dir: string): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const fullPath = join(dir, entry);
+    if (statSync(fullPath).isDirectory()) {
+      files.push(...collectTsFiles(fullPath));
+    } else if (entry.endsWith(".ts") && !entry.endsWith(".d.ts")) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+describe("플러그인 보안 체크리스트", () => {
+  const sourceFiles = collectTsFiles(SRC_DIR);
+
+  it("소스 파일이 존재한다", () => {
+    expect(sourceFiles.length).toBeGreaterThan(0);
+  });
+
+  it("eval() 호출이 없다", () => {
+    for (const file of sourceFiles) {
+      const content = readFileSync(file, "utf-8");
+      // eval( 패턴 매치 (문자열 리터럴 내부 제외 불가하므로 단순 검사)
+      expect(content).not.toMatch(/\beval\s*\(/);
+    }
+  });
+
+  it("new Function() 호출이 없다", () => {
+    for (const file of sourceFiles) {
+      const content = readFileSync(file, "utf-8");
+      expect(content).not.toMatch(/new\s+Function\s*\(/);
+    }
+  });
+
+  it("child_process 모듈 사용이 없다", () => {
+    for (const file of sourceFiles) {
+      const content = readFileSync(file, "utf-8");
+      expect(content).not.toMatch(/child_process/);
+    }
+  });
+
+  it("fs.writeFile / fs.unlink 직접 사용이 없다", () => {
+    for (const file of sourceFiles) {
+      const content = readFileSync(file, "utf-8");
+      expect(content).not.toMatch(/\bfs\.(writeFile|unlink|rmdir|rm)\b/);
+    }
+  });
+
+  it("process.env에서 토큰을 하드코딩하지 않는다", () => {
+    for (const file of sourceFiles) {
+      const content = readFileSync(file, "utf-8");
+      // 하드코딩된 토큰 패턴 (API key, secret 등)
+      expect(content).not.toMatch(
+        /["'](sk-|ghp_|gho_|Bearer\s+[A-Za-z0-9]{20,})["']/
+      );
+    }
+  });
+
+  describe("민감 필드 표시 (openclaw.plugin.json)", () => {
+    let pluginJson: Record<string, unknown>;
+
+    it("openclaw.plugin.json을 파싱할 수 있다", () => {
+      const content = readFileSync(
+        join(__dirname, "../../../openclaw.plugin.json"),
+        "utf-8"
+      );
+      pluginJson = JSON.parse(content);
+      expect(pluginJson).toBeDefined();
+    });
+
+    it("relayToken에 sensitive: true가 설정되어 있다", () => {
+      const content = readFileSync(
+        join(__dirname, "../../../openclaw.plugin.json"),
+        "utf-8"
+      );
+      pluginJson = JSON.parse(content);
+      const hints = pluginJson.uiHints as Record<
+        string,
+        { sensitive?: boolean }
+      >;
+      expect(hints["accounts.*.relayToken"]?.sensitive).toBe(true);
+    });
+
+    it("sessionToken에 sensitive: true가 설정되어 있다", () => {
+      const content = readFileSync(
+        join(__dirname, "../../../openclaw.plugin.json"),
+        "utf-8"
+      );
+      pluginJson = JSON.parse(content);
+      const hints = pluginJson.uiHints as Record<
+        string,
+        { sensitive?: boolean }
+      >;
+      expect(hints["accounts.*.sessionToken"]?.sensitive).toBe(true);
+    });
+  });
+
+  describe("토큰 상태 마스킹", () => {
+    it("relay 상태 응답에서 토큰 존재 여부를 직접 노출하지 않는다", () => {
+      const gatewayContent = readFileSync(
+        join(SRC_DIR, "adapters/gateway.ts"),
+        "utf-8"
+      );
+      // "토큰 없음" 같은 직접적인 토큰 유무 표시가 없어야 함
+      expect(gatewayContent).not.toContain('"토큰 없음"');
+      expect(gatewayContent).not.toContain("'토큰 없음'");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- 릴레이 상태 응답(`/relay`, `/session`)에서 토큰 존재 여부 직접 노출 제거
- README에 보안 섹션 추가 (토큰 관리, 릴레이 URL 요구사항, 스캐너 호환성)
- `tests/unit/security/plugin-safety.test.ts` 신규: eval/Function/child_process 미사용, sensitive 표시, 토큰 마스킹 확인 (10개 테스트)

## Test plan
- [x] `pnpm test:run` — 491 tests passed
- [x] `pnpm build` — tsc 성공
- [ ] `/relay` 명령어 실행 시 "토큰 없음" 대신 연결 상태 기반 표시 확인
- [ ] `/session` 명령어 실행 시 토큰 유무 직접 노출 없는지 확인

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)