### PR TITLE
feat: 업스트림 채널 패턴 분석 및 registerCommand/sendPayload 기반

### DIFF
--- a/docs/upstream-patterns.md
+++ b/docs/upstream-patterns.md
@@ -1,0 +1,74 @@
+# 업스트림 채널 패턴 분석
+
+OpenClaw 코어 및 다른 채널 플러그인(LINE, Feishu, device-pair)에서 참고할 수 있는 패턴을 정리합니다.
+
+## LINE 플러그인 패턴
+
+### Quick Reply 배치
+
+LINE 플러그인은 청크 분할 시 quick reply를 **마지막 청크에만** 부착합니다.
+
+```
+chunk 1 → 전송 (quick reply 없음)
+chunk 2 → 전송 (quick reply 없음)
+chunk 3 → 전송 (quick reply 부착)
+```
+
+**카카오 적용 가능성**: 현재 카카오 플러그인은 단일 응답에 quick reply를 포함하므로 즉시 적용 불필요. 다만 멀티 청크 응답 시 동일 패턴 적용을 검토할 수 있음.
+
+### Flex Message 빌더
+
+LINE은 구조화된 메시지를 Flex Message JSON으로 변환하는 빌더 유틸리티를 제공합니다.
+
+**카카오 적용 가능성**: 카카오 카드 빌더 유틸리티(`src/kakao/payload.ts`)에 해당하며, 현재 `tryParseKakaoCard()`로 구현되어 있음.
+
+## Feishu 플러그인 패턴
+
+### 미디어 전송 폴백
+
+Feishu는 미디어(이미지, 파일) 전송 실패 시 **URL 텍스트로 폴백**합니다:
+
+```
+이미지 전송 시도 → 실패 → "[이미지] https://example.com/img.jpg" 텍스트 전송
+```
+
+**카카오 적용 가능성**: `sendPayload()` 구현 시 미디어 전송 실패 폴백으로 적용 가능. 우선순위: 중간.
+
+### Typing Indicator
+
+Feishu는 응답 생성 중 타이핑 인디케이터를 표시합니다.
+
+**카카오 적용 가능성**: 카카오 챗봇 API에는 타이핑 인디케이터가 없으므로 적용 불가.
+
+## device-pair 플러그인 패턴
+
+### registerCommand
+
+`registerCommand()`를 사용하여 채널별 커맨드를 OpenClaw 커맨드 시스템에 등록합니다:
+
+```typescript
+api.registerCommand({
+  name: "pair",
+  description: "페어링 코드로 연결",
+  handler: async (ctx) => { /* ... */ },
+});
+```
+
+**카카오 적용 가능성**: 현재 `/help`, `/session` 등의 커맨드를 gateway 내부에서 처리 중. `registerCommand`로 전환하면 코어의 커맨드 검색/자동완성 기능과 연동 가능. 우선순위: 높음.
+
+## 적용 로드맵
+
+| 우선순위 | 패턴 | 출처 | 상태 |
+|---------|------|------|------|
+| 높음 | `registerCommand` 기반 커맨드 등록 | device-pair | 타입 정의 완료 (gateway 미연동) |
+| 높음 | `sendPayload` 채널 어댑터 메서드 | 코어 인터페이스 | 인터페이스 + no-op 스텁 (미구현) |
+| 중간 | 미디어 전송 URL 폴백 | Feishu | 향후 구현 |
+| 낮음 | Quick reply 마지막 청크 배치 | LINE | 멀티청크 지원 시 |
+| 불가 | Typing indicator | Feishu | 카카오 API 미지원 |
+
+## 후속 작업
+
+- [ ] `registerCommand`로 기존 `/help`, `/session` 등 커맨드 마이그레이션
+- [ ] `sendPayload()` 본격 구현 (카카오 카드 + simpleText 지원)
+- [ ] 미디어 전송 실패 시 URL 폴백 로직 추가
+- [ ] 멀티 청크 응답 시 quick reply 마지막 청크 배치

--- a/src/adapters/outbound.ts
+++ b/src/adapters/outbound.ts
@@ -1,4 +1,4 @@
-import type { ResolvedKakaoTalkChannel } from "../types.js";
+import type { ResolvedKakaoTalkChannel, KakaoSkillResponse } from "../types.js";
 import { chunkTextForKakao as chunkTextForKakaoImpl, type ChunkMode } from "../kakao/response.js";
 
 export interface OutboundContext {
@@ -21,6 +21,15 @@ export interface OutboundResult {
   error?: string;
 }
 
+/** sendPayload 전용 컨텍스트 */
+export interface SendPayloadContext {
+  to: string;
+  talkchannelId: string;
+  talkchannel: ResolvedKakaoTalkChannel;
+  messageId: string;
+  response: KakaoSkillResponse;
+}
+
 export interface ChannelOutboundAdapter {
   deliveryMode: "direct" | "gateway";
   textChunkLimit: number;
@@ -29,6 +38,7 @@ export interface ChannelOutboundAdapter {
   chunker: (text: string, limit: number, mode?: ChunkMode) => string[];
   sendText: (ctx: OutboundContext) => Promise<OutboundResult>;
   sendMedia?: (ctx: OutboundMediaContext) => Promise<OutboundResult>;
+  sendPayload?: (ctx: SendPayloadContext) => Promise<OutboundResult>;
 }
 
 export function chunkTextForKakao(text: string, limit: number = 400, mode: ChunkMode = "sentence"): string[] {
@@ -47,6 +57,17 @@ export const outboundAdapter: ChannelOutboundAdapter = {
   },
 
   sendMedia: async (_ctx: OutboundMediaContext): Promise<OutboundResult> => {
+    return { channel: "kakao-talkchannel", success: true };
+  },
+
+  /**
+   * 카카오 카드/구조화 메시지를 릴레이 서버로 직접 전송한다.
+   * 향후 gateway deliver 로직을 이 메서드로 통합할 수 있다.
+   *
+   * @see docs/upstream-patterns.md - sendPayload 패턴
+   */
+  sendPayload: async (_ctx: SendPayloadContext): Promise<OutboundResult> => {
+    // TODO: sendReply()를 호출하여 릴레이 서버로 전송
     return { channel: "kakao-talkchannel", success: true };
   },
 };

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -14,6 +14,7 @@ import { pairingAdapter } from "./adapters/pairing.js";
 import { gatewayAdapter, getPendingPairingInfo } from "./adapters/gateway.js";
 import { setupAdapter } from "./adapters/setup.js";
 import { KakaoChannelConfigSchema } from "./config/schema.js";
+import { statusCommand, type CommandDefinition } from "./commands/status.js";
 
 const meta = {
   id: "kakao-talkchannel",
@@ -45,6 +46,9 @@ export const kakaoPlugin = {
 
   reload: { configPrefixes: ["channels.kakao-talkchannel"] },
 
+  /** 향후 registerCommand 연동을 위한 커맨드 정의 목록 */
+  commands: [statusCommand],
+
   configSchema: {
     schema: KakaoChannelConfigSchema,
   },
@@ -68,6 +72,7 @@ export const kakaoPlugin = {
     blockStreaming: boolean;
   };
   reload: { configPrefixes: string[] };
+  commands: CommandDefinition[];
   configSchema: { schema: typeof KakaoChannelConfigSchema };
   config: typeof configAdapter;
   security: typeof securityAdapter;

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,0 +1,57 @@
+/**
+ * /status 커맨드 — registerCommand 패턴 기반
+ *
+ * device-pair 플러그인의 registerCommand 패턴을 참고하여
+ * 향후 코어 커맨드 시스템 연동을 위한 기반을 마련한다.
+ *
+ * @see docs/upstream-patterns.md
+ */
+
+export interface CommandDefinition {
+  name: string;
+  description: string;
+  aliases?: string[];
+}
+
+export interface CommandContext {
+  userId: string;
+  accountId: string;
+  args: string[];
+}
+
+export interface CommandResult {
+  text?: string;
+  handled: boolean;
+}
+
+/**
+ * /status 커맨드 정의
+ *
+ * 향후 api.registerCommand()를 통해 코어에 등록할 수 있는 형태.
+ */
+export const statusCommand: CommandDefinition = {
+  name: "status",
+  description: "릴레이 연결 상태 및 플러그인 상태를 확인합니다",
+  aliases: ["st"],
+};
+
+/**
+ * /status 커맨드 핸들러
+ *
+ * 현재는 간단한 상태 텍스트를 반환한다.
+ * 향후 statusAdapter.probeTalkChannel()과 연동하여
+ * 실시간 릴레이 상태를 포함할 수 있다.
+ */
+export async function handleStatusCommand(
+  ctx: CommandContext
+): Promise<CommandResult> {
+  const statusText =
+    `플러그인: kakao-talkchannel\n` +
+    `계정: ${ctx.accountId}\n` +
+    `사용자: ${ctx.userId}`;
+
+  return {
+    text: statusText,
+    handled: true,
+  };
+}

--- a/tests/unit/adapters/outbound.test.ts
+++ b/tests/unit/adapters/outbound.test.ts
@@ -9,6 +9,7 @@ import { describe, it, expect } from "vitest";
 import type {
   ChannelOutboundAdapter,
   OutboundContext,
+  SendPayloadContext,
 } from "../../../src/adapters/outbound.js";
 import {
   outboundAdapter,
@@ -337,6 +338,39 @@ describe("outboundAdapter.sendMedia", () => {
       mediaUrl: "https://example.com/image.jpg",
     };
     const result = outboundAdapter.sendMedia!(ctx);
+    expect(result instanceof Promise).toBe(true);
+  });
+});
+
+// ============================================================================
+// Test Suite: sendPayload Method
+// ============================================================================
+
+describe("outboundAdapter.sendPayload", () => {
+  const createPayloadContext = (): SendPayloadContext => ({
+    to: "user_123",
+    talkchannelId: "test-account-123",
+    talkchannel: mockTalkChannel,
+    messageId: "msg_001",
+    response: {
+      version: "2.0",
+      template: { outputs: [{ simpleText: { text: "hello" } }] },
+    },
+  });
+
+  it("should be defined", () => {
+    expect(outboundAdapter.sendPayload).toBeDefined();
+  });
+
+  it("should return OutboundResult with success flag", async () => {
+    const result = await outboundAdapter.sendPayload!(createPayloadContext());
+
+    expect(result.success).toBe(true);
+    expect(result.channel).toBe("kakao-talkchannel");
+  });
+
+  it("should be an async function", () => {
+    const result = outboundAdapter.sendPayload!(createPayloadContext());
     expect(result instanceof Promise).toBe(true);
   });
 });

--- a/tests/unit/channel.test.ts
+++ b/tests/unit/channel.test.ts
@@ -65,4 +65,11 @@ describe("kakaoPlugin", () => {
     expect(kakaoPlugin).toHaveProperty("security");
     expect(kakaoPlugin).toHaveProperty("pairing");
   });
+
+  it("has commands array with statusCommand", () => {
+    expect(kakaoPlugin.commands).toBeDefined();
+    expect(Array.isArray(kakaoPlugin.commands)).toBe(true);
+    expect(kakaoPlugin.commands.length).toBeGreaterThan(0);
+    expect(kakaoPlugin.commands[0].name).toBe("status");
+  });
 });

--- a/tests/unit/commands/status.test.ts
+++ b/tests/unit/commands/status.test.ts
@@ -1,0 +1,65 @@
+/**
+ * /status 커맨드 테스트
+ */
+import { describe, it, expect } from "vitest";
+import {
+  statusCommand,
+  handleStatusCommand,
+} from "../../../src/commands/status";
+
+describe("statusCommand 정의", () => {
+  it("name이 'status'이다", () => {
+    expect(statusCommand.name).toBe("status");
+  });
+
+  it("description이 정의되어 있다", () => {
+    expect(statusCommand.description).toBeTruthy();
+    expect(statusCommand.description).toContain("릴레이");
+  });
+
+  it("aliases에 'st'가 포함된다", () => {
+    expect(statusCommand.aliases).toEqual(["st"]);
+  });
+});
+
+describe("handleStatusCommand", () => {
+  it("handled: true를 반환한다", async () => {
+    const result = await handleStatusCommand({
+      userId: "user123",
+      accountId: "default",
+      args: [],
+    });
+
+    expect(result.handled).toBe(true);
+  });
+
+  it("상태 텍스트에 userId를 포함한다", async () => {
+    const result = await handleStatusCommand({
+      userId: "kakao-user-456",
+      accountId: "default",
+      args: [],
+    });
+
+    expect(result.text).toContain("kakao-user-456");
+  });
+
+  it("상태 텍스트에 accountId를 포함한다", async () => {
+    const result = await handleStatusCommand({
+      userId: "user1",
+      accountId: "my-account",
+      args: [],
+    });
+
+    expect(result.text).toContain("my-account");
+  });
+
+  it("상태 텍스트에 플러그인 이름을 포함한다", async () => {
+    const result = await handleStatusCommand({
+      userId: "user1",
+      accountId: "default",
+      args: [],
+    });
+
+    expect(result.text).toContain("kakao-talkchannel");
+  });
+});


### PR DESCRIPTION
## Summary
- LINE, Feishu, device-pair 플러그인 패턴 분석 결과 문서화 (`docs/upstream-patterns.md`)
- `src/commands/status.ts`: registerCommand 패턴 기반 `/status` 커맨드 타입 정의 (gateway 미연동 — 향후 registerCommand API로 통합 예정)
- `src/adapters/outbound.ts`: `sendPayload` 인터페이스 + no-op 스텁
- `src/channel.ts`: commands 배열에 statusCommand 등록, `satisfies` 타입에 `CommandDefinition[]` 추가
- 테스트: status 커맨드 (7개), sendPayload (3개), commands 배열 (1개) 추가

## Test plan
- [x] `pnpm test:run` — 492 tests passed
- [x] `pnpm build` — tsc 성공
- [ ] 후속 작업으로 `/status`를 `PLUGIN_COMMANDS`에 연동
- [ ] 후속 작업으로 `sendPayload()`에 sendReply() 호출 구현

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)