### PR TITLE
fix(ci): npm 배포 파이프라인 수정 (install 단계 auth 분리, node 22)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -36,15 +36,19 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "pnpm"
-          registry-url: "https://registry.npmjs.org"
 
       - run: pnpm install --frozen-lockfile
 
       - run: pnpm build
 
       - run: pnpm test:run
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
 
       - run: pnpm publish --access public --no-git-checks
         env:


### PR DESCRIPTION
## Summary

- `pnpm install` 단계에서 `NPM_TOKEN`이 auth 헤더로 적용되어 `ERR_PNPM_FETCH_403` 발생하는 문제 수정
- `setup-node`의 `registry-url` 설정을 `publish` 단계 직전으로 이동 → install/build/test는 인증 없이 실행
- `node-version` 20 → 22 변경 (package.json `engines: >=22.12.0` 요건 충족)

## Root Cause

`actions/setup-node`에 `registry-url`을 설정하면 `.npmrc`에 `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}`이 기록됩니다. 이후 `pnpm install` 실행 시 이 토큰이 모든 npm 요청에 포함되어, 유효하지 않은 토큰이면 공개 패키지 다운로드에도 403이 발생합니다.

## Before / After

**Before:** `setup-node(registry-url)` → `pnpm install` ❌ 403 → `pnpm publish` (미실행)

**After:** `setup-node` → `pnpm install` ✅ → `pnpm build/test` → `setup-node(registry-url)` → `pnpm publish`

## 추가 조치 필요 (워크플로우 수정 외)

GitHub repository secrets에 **`NPM_TOKEN`** 이 설정되어 있어야 합니다.

1. [npmjs.org](https://www.npmjs.com) → Account Settings → Access Tokens → Generate New Token (Publish 권한)
2. GitHub repo → Settings → Secrets and variables → Actions → New repository secret → `NPM_TOKEN`

> 이슈 #29: `@openclaw/kakao-talkchannel` npm 404 제보 ([@mammonite](https://github.com/mammonite))

## Test plan

- [ ] 이 PR merge 후, 다음 release-please 릴리즈 시 publish job 성공 확인
- [ ] `NPM_TOKEN` secret 설정 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)